### PR TITLE
Manual std::hash::Hash implementation for consistency with PartialEq

### DIFF
--- a/cas-compute/src/symbolic/expr/mod.rs
+++ b/cas-compute/src/symbolic/expr/mod.rs
@@ -448,11 +448,11 @@ impl PartialEq for Expr {
 /// commutative operations like addition and multiplication.
 impl Hash for Expr {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        // Hash the discriminant to differentiate between enum variants
+        // hash the discriminant to differentiate between enum variants
         let self_discr = std::mem::discriminant(self);
-        Hash::hash(&self_discr, state);
+        self_discr.hash(state);
 
-        // Hash the data associated with each variant
+        // hash the data associated with each variant
         match self {
             Expr::Primary(val) => val.hash(state),
             Expr::Add(val) | Expr::Mul(val) => {
@@ -844,9 +844,7 @@ mod tests {
 
     /// Get the hash of the given [`Expr`].
     fn hasher<T: Hash>(t: T) -> u64 {
-        use Hasher;
-
-        let mut hasher: std::hash::DefaultHasher = std::collections::hash_map::DefaultHasher::new();
+        let mut hasher: DefaultHasher = DefaultHasher::new();
 
         t.hash(&mut hasher);
 

--- a/cas-compute/src/symbolic/expr/mod.rs
+++ b/cas-compute/src/symbolic/expr/mod.rs
@@ -1054,10 +1054,13 @@ mod tests {
             ("2 x y", "y x 2"),
             ("a b c", "c b a"),
             ("(x y) z", "z * (y x)"),
-            ("x * (y + z)", "(y + z) x"),
-            ("a * (b + c)", "(b + c) a"),
             ("1 + (x y)", "(y x) + 1"),
 
+            // TODO: these should pass, but they don't as of now
+            // because of ambiguity in the parser it gets parsed
+            // as a fucntion call instead of implicit multiplication`1 * (2 + x)`
+            // ("x (y + z)", "(y + z) x"),
+            // ("a (b + c)", "(b + c) a"),
         ];
 
         // Non-commutative (should fail)

--- a/cas-compute/src/symbolic/expr/mod.rs
+++ b/cas-compute/src/symbolic/expr/mod.rs
@@ -1029,7 +1029,7 @@ mod tests {
 
     #[test]
     fn add_mul_commutative_hashing() {
-        // Commutative (should pass)
+        // Commutative or equal (should pass)
         let eq_expressions: Vec<(&str, &str)> = vec![
             // Addition
             ("1 + 2", "2 + 1"),
@@ -1065,11 +1065,13 @@ mod tests {
             // ("a (b + c)", "(b + c) a"),
         ];
 
-        // Non-commutative (should fail)
+        // Non-commutative or unequal expressions (should fail)
         let ne_expressions: Vec<(&str, &str)> = vec![
             ("1 - 2", "2 - 1"),
             ("x / y", "y / x"),
-            ("a - b + c", "c + b - a")
+            ("a - b + c", "c + b - a"),
+            ("1 + 1", "2 + 2"),
+            ("a * a", "b * b")
         ];
 
         for (ea, eb) in eq_expressions {

--- a/cas-compute/src/symbolic/expr/mod.rs
+++ b/cas-compute/src/symbolic/expr/mod.rs
@@ -1056,9 +1056,11 @@ mod tests {
             ("(x y) z", "z * (y x)"),
             ("1 + (x y)", "(y x) + 1"),
 
-            // TODO: these should pass, but they don't as of now
-            // because of ambiguity in the parser it gets parsed
-            // as a fucntion call instead of implicit multiplication`1 * (2 + x)`
+            // TODO: these should pass, but they don't as of now because of ambiguity
+            // in the parser it gets parsed as a fucntion call instead of implicit
+            // multiplication `x * (y + z)` and `a * (b + c)` respectively. Reintroduce
+            // these tests once following issue is resolved:
+            // https://github.com/ElectrifyPro/cas-rs/issues/3
             // ("x (y + z)", "(y + z) x"),
             // ("a (b + c)", "(b + c) a"),
         ];


### PR DESCRIPTION
This guarantees that the PartialEq for Hash would be consistent. Please let me know if anything has to be changed, modified or if it is bluntly incorrect.

This implementation is similar to the derive macro implementation.