### PR TITLE
Rename symbolic `Expr` to `SymExpr`

### DIFF
--- a/cas-compute/README.md
+++ b/cas-compute/README.md
@@ -57,18 +57,18 @@ See its [module-level documentation](symbolic) for more information.
 
 ```rust
 use cas_compute::primitive::int;
-use cas_compute::symbolic::{expr::{Expr, Primary}, simplify};
-use cas_parser::parser::{ast::Expr as AstExpr, Parser};
+use cas_compute::symbolic::{expr::{SymExpr, Primary}, simplify};
+use cas_parser::parser::{ast::Expr, Parser};
 
 let mut parser = Parser::new("x + x + x");
-let ast_expr = parser.try_parse_full::<AstExpr>().unwrap();
+let ast_expr = parser.try_parse_full::<Expr>().unwrap();
 
 let simplified = simplify(&ast_expr.into());
 
 // `x + x + x = 3x`
-assert_eq!(simplified, Expr::Mul(vec![
-    Expr::Primary(Primary::Integer(int(3))),
-    Expr::Primary(Primary::Symbol("x".to_string())),
+assert_eq!(simplified, SymExpr::Mul(vec![
+    SymExpr::Primary(Primary::Integer(int(3))),
+    SymExpr::Primary(Primary::Symbol("x".to_string())),
 ]));
 ```
 

--- a/cas-compute/src/symbolic/expr/iter.rs
+++ b/cas-compute/src/symbolic/expr/iter.rs
@@ -1,18 +1,18 @@
-use super::Expr;
+use super::SymExpr;
 
 /// An iterator that iteratively traverses the tree of expressions in left-to-right post-order
 /// (i.e. depth-first).
 ///
 /// This iterator is created by [`Expr::post_order_iter`].
 pub struct ExprIter<'a> {
-    stack: Vec<&'a Expr>,
-    last_visited: Option<&'a Expr>,
+    stack: Vec<&'a SymExpr>,
+    last_visited: Option<&'a SymExpr>,
 }
 
 impl<'a> ExprIter<'a> {
     /// Creates a new iterator that traverses the tree of expressions in left-to-right post-order
     /// (i.e. depth-first).
-    pub fn new(expr: &'a Expr) -> Self {
+    pub fn new(expr: &'a SymExpr) -> Self {
         Self {
             stack: vec![expr],
             last_visited: None,
@@ -20,13 +20,13 @@ impl<'a> ExprIter<'a> {
     }
 
     /// Pops the current expression in the stack and marks it as the last visited expression.
-    fn visit(&mut self) -> Option<&'a Expr> {
+    fn visit(&mut self) -> Option<&'a SymExpr> {
         self.last_visited = Some(self.stack.pop()?);
         self.last_visited
     }
 
     /// Returns true if the given expression matches the last visited expression.
-    fn is_last_visited(&self, expr: &'a Expr) -> bool {
+    fn is_last_visited(&self, expr: &'a SymExpr) -> bool {
         match self.last_visited {
             Some(last_visited) => std::ptr::eq(last_visited, expr),
             None => false,
@@ -35,14 +35,14 @@ impl<'a> ExprIter<'a> {
 }
 
 impl<'a> Iterator for ExprIter<'a> {
-    type Item = &'a Expr;
+    type Item = &'a SymExpr;
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
             let expr = self.stack.last()?;
             match expr {
-                Expr::Primary(_) => return self.visit(),
-                Expr::Add(terms) => {
+                SymExpr::Primary(_) => return self.visit(),
+                SymExpr::Add(terms) => {
                     if terms.is_empty() || self.is_last_visited(terms.last().unwrap()) {
                         return self.visit();
                     }
@@ -50,7 +50,7 @@ impl<'a> Iterator for ExprIter<'a> {
                         self.stack.push(term);
                     }
                 },
-                Expr::Mul(factors) => {
+                SymExpr::Mul(factors) => {
                     if factors.is_empty() || self.is_last_visited(factors.last().unwrap()) {
                         return self.visit();
                     }
@@ -58,7 +58,7 @@ impl<'a> Iterator for ExprIter<'a> {
                         self.stack.push(factor);
                     }
                 },
-                Expr::Exp(lhs, rhs) => {
+                SymExpr::Exp(lhs, rhs) => {
                     if self.is_last_visited(rhs) {
                         return self.visit();
                     }

--- a/cas-compute/src/symbolic/mod.rs
+++ b/cas-compute/src/symbolic/mod.rs
@@ -28,7 +28,7 @@
 //! let mut parser = Parser::new("x + (y + z)");
 //! let ast_expr = parser.try_parse_full::<Expr>().unwrap();
 //!
-//! let expr = ast_expr.into();
+//! let expr: SymExpr = ast_expr.into();
 //! assert_eq!(expr, SymExpr::Add(vec![
 //!     SymExpr::Primary(Primary::Symbol("x".to_string())),
 //!     SymExpr::Primary(Primary::Symbol("y".to_string())),
@@ -57,17 +57,17 @@
 //!
 //! ```
 //! use cas_compute::primitive::int;
-//! use cas_compute::symbolic::{expr::{Expr, Primary}, simplify};
-//! use cas_parser::parser::{ast::Expr as AstExpr, Parser};
+//! use cas_compute::symbolic::{expr::{Primary, SymExpr}, simplify};
+//! use cas_parser::parser::{ast::Expr, Parser};
 //!
 //! let mut parser = Parser::new("x + x + x");
-//! let ast_expr = parser.try_parse_full::<AstExpr>().unwrap();
+//! let ast_expr = parser.try_parse_full::<Expr>().unwrap();
 //! let simplified = simplify(&ast_expr.into());
 //!
 //! // `x + x + x = 3x`
-//! assert_eq!(simplified, Expr::Mul(vec![
-//!     Expr::Primary(Primary::Integer(int(3))),
-//!     Expr::Primary(Primary::Symbol("x".to_string())),
+//! assert_eq!(simplified, SymExpr::Mul(vec![
+//!     SymExpr::Primary(Primary::Integer(int(3))),
+//!     SymExpr::Primary(Primary::Symbol("x".to_string())),
 //! ]));
 //! ```
 //!

--- a/cas-compute/src/symbolic/mod.rs
+++ b/cas-compute/src/symbolic/mod.rs
@@ -2,13 +2,12 @@
 //!
 //! # Expression representation
 //!
-//! Algebraic expressions in this module are represented as a tree of [`expr::Expr`] nodes, which
-//! should be distinguished from the [`cas_parser::parser::ast::Expr`] nodes produced by
-//! [`cas_parser`]. The main difference is that [`expr::Expr`] nodes **flatten** out the tree
-//! structure.
+//! Algebraic expressions in this module are represented as a tree of [`SymExpr`] nodes. It's
+//! similar to the [`cas_parser::parser::ast::Expr`] nodes produced by [`cas_parser`], with the
+//! main difference being that [`SymExpr`] nodes **flatten** out the tree structure.
 //!
 //! For example, the expression `x + (y + z)` would be represented internally as a single
-//! [`expr::Expr::Add`] node with _three_ children, `x`, `y`, and `z`, where as the
+//! [`SymExpr::Add`] node with _three_ children, `x`, `y`, and `z`, where as the
 //! [`cas_parser::parser::ast::Expr`] node would have two children, `x` and `(y + z)`.
 //!
 //! This is done to make it easier to perform algebraic manipulations on the expression. A common
@@ -16,24 +15,24 @@
 //! share the same factors (e.g. `x + x = 2x`). This is much easier to do when the terms in
 //! question are all at the same level in the tree.
 //!
-//! If you have a [`cas_parser::parser::ast::Expr`], you can convert it to an [`expr::Expr`] using
-//! the [`From`] trait. It should be noted that conversion to [`expr::Expr`] is lossy, as
-//! [`expr::Expr`] does not store span information and is free to rearrange the terms and / or
+//! If you have a [`cas_parser::parser::ast::Expr`], you can convert it to an [`SymExpr`] using
+//! the [`From`] trait. It should be noted that conversion to [`SymExpr`] is lossy, as
+//! [`SymExpr`] does not store span information and is free to rearrange the terms and / or
 //! factors during conversion, however the resulting expression will be semantically equivalent to
 //! the original.
 //!
 //! ```
-//! use cas_compute::symbolic::expr::{Expr, Primary};
-//! use cas_parser::parser::{ast::Expr as AstExpr, Parser};
+//! use cas_compute::symbolic::expr::{Primary, SymExpr};
+//! use cas_parser::parser::{ast::Expr, Parser};
 //!
 //! let mut parser = Parser::new("x + (y + z)");
-//! let ast_expr = parser.try_parse_full::<AstExpr>().unwrap();
+//! let ast_expr = parser.try_parse_full::<Expr>().unwrap();
 //!
-//! let expr: Expr = ast_expr.into();
-//! assert_eq!(expr, Expr::Add(vec![
-//!     Expr::Primary(Primary::Symbol("x".to_string())),
-//!     Expr::Primary(Primary::Symbol("y".to_string())),
-//!     Expr::Primary(Primary::Symbol("z".to_string())),
+//! let expr = ast_expr.into();
+//! assert_eq!(expr, SymExpr::Add(vec![
+//!     SymExpr::Primary(Primary::Symbol("x".to_string())),
+//!     SymExpr::Primary(Primary::Symbol("y".to_string())),
+//!     SymExpr::Primary(Primary::Symbol("z".to_string())),
 //! ]));
 //! ```
 //!
@@ -78,6 +77,6 @@ pub mod expr;
 pub mod simplify;
 pub mod step_collector;
 
-pub use expr::Expr;
+pub use expr::SymExpr;
 pub use simplify::{simplify, simplify_with, simplify_with_steps};
 pub use step_collector::StepCollector;

--- a/cas-compute/src/symbolic/simplify/rules/distribute.rs
+++ b/cas-compute/src/symbolic/simplify/rules/distribute.rs
@@ -1,21 +1,21 @@
 //! Simplification rules related to the distributive property.
 
 use crate::symbolic::{
-    expr::Expr,
+    expr::SymExpr,
     simplify::{rules::{do_multiply, do_power}, step::Step},
     step_collector::StepCollector,
 };
 
 /// `a*(b+c) = a*b + a*c`
-pub fn distributive_property(expr: &Expr, step_collector: &mut dyn StepCollector<Step>) -> Option<Expr> {
+pub fn distributive_property(expr: &SymExpr, step_collector: &mut dyn StepCollector<Step>) -> Option<SymExpr> {
     let opt = do_multiply(expr, |factors| {
         // find the first `Expr::Add`, and distribute every other factor over it
         let mut factors_to_distribute = factors.to_vec();
         let add_factor_terms = {
             let idx = factors_to_distribute.iter()
-                .position(|factor| matches!(factor, Expr::Add(_)));
+                .position(|factor| matches!(factor, SymExpr::Add(_)));
             if let Some(idx) = idx {
-                if let Expr::Add(terms) = factors_to_distribute.swap_remove(idx) {
+                if let SymExpr::Add(terms) = factors_to_distribute.swap_remove(idx) {
                     terms
                 } else {
                     unreachable!()
@@ -27,10 +27,10 @@ pub fn distributive_property(expr: &Expr, step_collector: &mut dyn StepCollector
 
         let new_terms = add_factor_terms.into_iter()
             .map(|term| {
-                Expr::Mul(factors_to_distribute.clone()) * term
+                SymExpr::Mul(factors_to_distribute.clone()) * term
             })
             .collect::<Vec<_>>();
-        Some(Expr::Add(new_terms))
+        Some(SymExpr::Add(new_terms))
     })?;
 
     // keep the step collection logic outside of the closure to make it implement `Fn`
@@ -39,17 +39,17 @@ pub fn distributive_property(expr: &Expr, step_collector: &mut dyn StepCollector
 }
 
 /// `(a*b)^c = a^c * b^c`
-pub fn distribute_power(expr: &Expr, step_collector: &mut dyn StepCollector<Step>) -> Option<Expr> {
+pub fn distribute_power(expr: &SymExpr, step_collector: &mut dyn StepCollector<Step>) -> Option<SymExpr> {
     let opt = do_power(expr, |lhs, rhs| {
-        if let Expr::Mul(factors) = lhs {
+        if let SymExpr::Mul(factors) = lhs {
             let new_factors = factors.iter()
-                .map(|factor| Expr::Exp(
+                .map(|factor| SymExpr::Exp(
                     Box::new(factor.clone()),
                     Box::new(rhs.clone()),
                 ))
                 .collect::<Vec<_>>();
 
-            return Some(Expr::Mul(new_factors));
+            return Some(SymExpr::Mul(new_factors));
         }
 
         None
@@ -63,7 +63,7 @@ pub fn distribute_power(expr: &Expr, step_collector: &mut dyn StepCollector<Step
 ///
 /// The distributive property may or may not reduce the complexity of the expression, since it can
 /// introduce additional operations. However, it may be necessary for future rules to apply.
-pub fn all(expr: &Expr, step_collector: &mut dyn StepCollector<Step>) -> Option<Expr> {
+pub fn all(expr: &SymExpr, step_collector: &mut dyn StepCollector<Step>) -> Option<SymExpr> {
     distributive_property(expr, step_collector)
         .or_else(|| distribute_power(expr, step_collector))
 }

--- a/cas-compute/src/symbolic/simplify/rules/imaginary.rs
+++ b/cas-compute/src/symbolic/simplify/rules/imaginary.rs
@@ -2,7 +2,7 @@
 
 use crate::primitive::int;
 use crate::symbolic::{
-    expr::{Expr, Primary},
+    expr::{SymExpr, Primary},
     simplify::{rules::do_power, step::Step},
     step_collector::StepCollector,
 };
@@ -17,10 +17,10 @@ use crate::symbolic::{
 /// `i^(4n) = 1`
 ///
 /// `i^0` can be handled by `power_zero`, but this rule is more general.
-pub fn i_pow_0(expr: &Expr, step_collector: &mut dyn StepCollector<Step>) -> Option<Expr> {
+pub fn i_pow_0(expr: &SymExpr, step_collector: &mut dyn StepCollector<Step>) -> Option<SymExpr> {
     let opt = do_power(expr, |lhs, rhs| {
         if lhs.as_symbol()? == "i" && int(rhs.as_integer()? % 4).is_zero() {
-            Some(Expr::Primary(Primary::Integer(int(1))))
+            Some(SymExpr::Primary(Primary::Integer(int(1))))
         } else {
             None
         }
@@ -31,10 +31,10 @@ pub fn i_pow_0(expr: &Expr, step_collector: &mut dyn StepCollector<Step>) -> Opt
 }
 
 /// `i^(4n+1) = i`
-pub fn i_pow_1(expr: &Expr, step_collector: &mut dyn StepCollector<Step>) -> Option<Expr> {
+pub fn i_pow_1(expr: &SymExpr, step_collector: &mut dyn StepCollector<Step>) -> Option<SymExpr> {
     let opt = do_power(expr, |lhs, rhs| {
         if lhs.as_symbol()? == "i" && int(rhs.as_integer()? % 4) == 1 {
-            Some(Expr::Primary(Primary::Symbol("i".to_string())))
+            Some(SymExpr::Primary(Primary::Symbol("i".to_string())))
         } else {
             None
         }
@@ -45,10 +45,10 @@ pub fn i_pow_1(expr: &Expr, step_collector: &mut dyn StepCollector<Step>) -> Opt
 }
 
 /// `i^(4n+2) = -1`
-pub fn i_pow_2(expr: &Expr, step_collector: &mut dyn StepCollector<Step>) -> Option<Expr> {
+pub fn i_pow_2(expr: &SymExpr, step_collector: &mut dyn StepCollector<Step>) -> Option<SymExpr> {
     let opt = do_power(expr, |lhs, rhs| {
         if lhs.as_symbol()? == "i" && int(rhs.as_integer()? % 4) == 2 {
-            Some(Expr::Primary(Primary::Integer(int(-1))))
+            Some(SymExpr::Primary(Primary::Integer(int(-1))))
         } else {
             None
         }
@@ -59,10 +59,10 @@ pub fn i_pow_2(expr: &Expr, step_collector: &mut dyn StepCollector<Step>) -> Opt
 }
 
 /// `i^(4n+3) = -i`
-pub fn i_pow_3(expr: &Expr, step_collector: &mut dyn StepCollector<Step>) -> Option<Expr> {
+pub fn i_pow_3(expr: &SymExpr, step_collector: &mut dyn StepCollector<Step>) -> Option<SymExpr> {
     let opt = do_power(expr, |lhs, rhs| {
         if lhs.as_symbol()? == "i" && int(rhs.as_integer()? % 4) == 3 {
-            Some(-Expr::Primary(Primary::Symbol("i".to_string())))
+            Some(-SymExpr::Primary(Primary::Symbol("i".to_string())))
         } else {
             None
         }
@@ -75,7 +75,7 @@ pub fn i_pow_3(expr: &Expr, step_collector: &mut dyn StepCollector<Step>) -> Opt
 /// Applies all imaginary unit rules.
 ///
 /// All imaginary unit rules will reduce the complexity of the expression.
-pub fn all(expr: &Expr, step_collector: &mut dyn StepCollector<Step>) -> Option<Expr> {
+pub fn all(expr: &SymExpr, step_collector: &mut dyn StepCollector<Step>) -> Option<SymExpr> {
     i_pow_0(expr, step_collector)
         .or_else(|| i_pow_1(expr, step_collector))
         .or_else(|| i_pow_2(expr, step_collector))

--- a/cas-compute/src/symbolic/simplify/rules/mod.rs
+++ b/cas-compute/src/symbolic/simplify/rules/mod.rs
@@ -13,18 +13,18 @@ pub mod root;
 pub mod trigonometry;
 
 use crate::symbolic::step_collector::StepCollector;
-use super::{Expr, Primary, step::Step};
+use super::{SymExpr, Primary, step::Step};
 
 /// If the expression is a function call with the given function name, calls the given
 /// transformation function with the arguments.
 ///
 /// Returns `Some(expr)` with the transformed expression if a transformation was applied.
 pub(crate) fn do_call(
-    expr: &Expr,
+    expr: &SymExpr,
     name: &str,
-    f: impl Copy + Fn(&[Expr]) -> Option<Expr>,
-) -> Option<Expr> {
-    if let Expr::Primary(Primary::Call(target_name, args)) = expr {
+    f: impl Copy + Fn(&[SymExpr]) -> Option<SymExpr>,
+) -> Option<SymExpr> {
+    if let SymExpr::Primary(Primary::Call(target_name, args)) = expr {
         if target_name == name {
             return f(args);
         }
@@ -36,8 +36,8 @@ pub(crate) fn do_call(
 /// If the expression is an add expression, calls the given transformation function with the terms.
 ///
 /// Returns `Some(expr)` with the transformed expression if a transformation was applied.
-pub(crate) fn do_add(expr: &Expr, f: impl Copy + Fn(&[Expr]) -> Option<Expr>) -> Option<Expr> {
-    if let Expr::Add(terms) = expr {
+pub(crate) fn do_add(expr: &SymExpr, f: impl Copy + Fn(&[SymExpr]) -> Option<SymExpr>) -> Option<SymExpr> {
+    if let SymExpr::Add(terms) = expr {
         f(terms)
     } else {
         None
@@ -48,8 +48,8 @@ pub(crate) fn do_add(expr: &Expr, f: impl Copy + Fn(&[Expr]) -> Option<Expr>) ->
 /// the factors.
 ///
 /// Returns `Some(expr)` with the transformed expression if a transformation was applied.
-pub(crate) fn do_multiply(expr: &Expr, f: impl Copy + Fn(&[Expr]) -> Option<Expr>) -> Option<Expr> {
-    if let Expr::Mul(factors) = expr {
+pub(crate) fn do_multiply(expr: &SymExpr, f: impl Copy + Fn(&[SymExpr]) -> Option<SymExpr>) -> Option<SymExpr> {
+    if let SymExpr::Mul(factors) = expr {
         f(factors)
     } else {
         None
@@ -60,8 +60,8 @@ pub(crate) fn do_multiply(expr: &Expr, f: impl Copy + Fn(&[Expr]) -> Option<Expr
 /// and right-hand-side of the power.
 ///
 /// Returns `Some(expr)` with the transformed expression if a transformation was applied.
-pub(crate) fn do_power(expr: &Expr, f: impl Copy + Fn(&Expr, &Expr) -> Option<Expr>) -> Option<Expr> {
-    if let Expr::Exp(lhs, rhs) = expr {
+pub(crate) fn do_power(expr: &SymExpr, f: impl Copy + Fn(&SymExpr, &SymExpr) -> Option<SymExpr>) -> Option<SymExpr> {
+    if let SymExpr::Exp(lhs, rhs) = expr {
         f(lhs, rhs)
     } else {
         None
@@ -69,7 +69,7 @@ pub(crate) fn do_power(expr: &Expr, f: impl Copy + Fn(&Expr, &Expr) -> Option<Ex
 }
 
 /// Applies all rules.
-pub fn all(expr: &Expr, step_collector: &mut dyn StepCollector<Step>) -> Option<Expr> {
+pub fn all(expr: &SymExpr, step_collector: &mut dyn StepCollector<Step>) -> Option<SymExpr> {
     add::all(expr, step_collector)
         .or_else(|| multiply::all(expr, step_collector))
         .or_else(|| power::all(expr, step_collector))

--- a/cas-compute/src/symbolic/simplify/rules/trigonometry/consts.rs
+++ b/cas-compute/src/symbolic/simplify/rules/trigonometry/consts.rs
@@ -2,22 +2,22 @@
 
 use crate::primitive::int;
 use crate::symbolic::{
-    expr::{Expr, Primary},
+    expr::{SymExpr, Primary},
     simplify::fraction::make_fraction,
 };
 use once_cell::sync::Lazy;
 
-/// The number one, wrapped in an [`Expr`].
-pub static ONE: Lazy<Expr> = Lazy::new(|| Expr::Primary(Primary::Integer(int(1))));
+/// The number one, wrapped in a [`SymExpr`].
+pub static ONE: Lazy<SymExpr> = Lazy::new(|| SymExpr::Primary(Primary::Integer(int(1))));
 
-/// The number 1/2, wrapped in an [`Expr`].
-pub static ONE_HALF: Lazy<Expr> = Lazy::new(|| make_fraction(
-    Expr::Primary(Primary::Integer(int(1))),
-    Expr::Primary(Primary::Integer(int(2))),
+/// The number 1/2, wrapped in a [`SymExpr`].
+pub static ONE_HALF: Lazy<SymExpr> = Lazy::new(|| make_fraction(
+    SymExpr::Primary(Primary::Integer(int(1))),
+    SymExpr::Primary(Primary::Integer(int(2))),
 ));
 
-/// The number zero, wrapped in an [`Expr`].
-pub static ZERO: Lazy<Expr> = Lazy::new(|| Expr::Primary(Primary::Integer(int(0))));
+/// The number zero, wrapped in a [`SymExpr`].
+pub static ZERO: Lazy<SymExpr> = Lazy::new(|| SymExpr::Primary(Primary::Integer(int(0))));
 
 /// Relevant fractions of a unit circle.
 ///
@@ -37,88 +37,88 @@ pub mod input {
     use super::*;
 
     /// 1/12 = pi/6 rad = 30 deg
-    pub static ONE_TWELFTH: Lazy<Expr> = Lazy::new(|| make_fraction(
-        Expr::Primary(Primary::Integer(int(1))),
-        Expr::Primary(Primary::Integer(int(12))),
+    pub static ONE_TWELFTH: Lazy<SymExpr> = Lazy::new(|| make_fraction(
+        SymExpr::Primary(Primary::Integer(int(1))),
+        SymExpr::Primary(Primary::Integer(int(12))),
     ));
 
     /// 1/8 = pi/4 rad = 45 deg
-    pub static ONE_EIGHTH: Lazy<Expr> = Lazy::new(|| make_fraction(
-        Expr::Primary(Primary::Integer(int(1))),
-        Expr::Primary(Primary::Integer(int(8))),
+    pub static ONE_EIGHTH: Lazy<SymExpr> = Lazy::new(|| make_fraction(
+        SymExpr::Primary(Primary::Integer(int(1))),
+        SymExpr::Primary(Primary::Integer(int(8))),
     ));
 
     /// 1/6 = pi/3 rad = 60 deg
-    pub static ONE_SIXTH: Lazy<Expr> = Lazy::new(|| make_fraction(
-        Expr::Primary(Primary::Integer(int(1))),
-        Expr::Primary(Primary::Integer(int(6))),
+    pub static ONE_SIXTH: Lazy<SymExpr> = Lazy::new(|| make_fraction(
+        SymExpr::Primary(Primary::Integer(int(1))),
+        SymExpr::Primary(Primary::Integer(int(6))),
     ));
 
     /// 1/4 = pi/2 rad = 90 deg
-    pub static ONE_FOURTH: Lazy<Expr> = Lazy::new(|| make_fraction(
-        Expr::Primary(Primary::Integer(int(1))),
-        Expr::Primary(Primary::Integer(int(4))),
+    pub static ONE_FOURTH: Lazy<SymExpr> = Lazy::new(|| make_fraction(
+        SymExpr::Primary(Primary::Integer(int(1))),
+        SymExpr::Primary(Primary::Integer(int(4))),
     ));
 
     /// 1/3 = 2pi/3 rad = 120 deg
-    pub static ONE_THIRD: Lazy<Expr> = Lazy::new(|| make_fraction(
-        Expr::Primary(Primary::Integer(int(1))),
-        Expr::Primary(Primary::Integer(int(3))),
+    pub static ONE_THIRD: Lazy<SymExpr> = Lazy::new(|| make_fraction(
+        SymExpr::Primary(Primary::Integer(int(1))),
+        SymExpr::Primary(Primary::Integer(int(3))),
     ));
 
     /// 3/8 = 3pi/4 rad = 135 deg
-    pub static THREE_EIGHTS: Lazy<Expr> = Lazy::new(|| make_fraction(
-        Expr::Primary(Primary::Integer(int(3))),
-        Expr::Primary(Primary::Integer(int(8))),
+    pub static THREE_EIGHTS: Lazy<SymExpr> = Lazy::new(|| make_fraction(
+        SymExpr::Primary(Primary::Integer(int(3))),
+        SymExpr::Primary(Primary::Integer(int(8))),
     ));
 
     /// 5/12 = 5pi/6 rad = 150 deg
-    pub static FIVE_TWELFTHS: Lazy<Expr> = Lazy::new(|| make_fraction(
-        Expr::Primary(Primary::Integer(int(5))),
-        Expr::Primary(Primary::Integer(int(12))),
+    pub static FIVE_TWELFTHS: Lazy<SymExpr> = Lazy::new(|| make_fraction(
+        SymExpr::Primary(Primary::Integer(int(5))),
+        SymExpr::Primary(Primary::Integer(int(12))),
     ));
 
     // lower half
     /// 7/12 = 7pi/6 rad = 210 deg
-    pub static SEVEN_TWELFTHS: Lazy<Expr> = Lazy::new(|| make_fraction(
-        Expr::Primary(Primary::Integer(int(7))),
-        Expr::Primary(Primary::Integer(int(12))),
+    pub static SEVEN_TWELFTHS: Lazy<SymExpr> = Lazy::new(|| make_fraction(
+        SymExpr::Primary(Primary::Integer(int(7))),
+        SymExpr::Primary(Primary::Integer(int(12))),
     ));
 
     /// 5/8 = 5pi/4 rad = 225 deg
-    pub static FIVE_EIGHTHS: Lazy<Expr> = Lazy::new(|| make_fraction(
-        Expr::Primary(Primary::Integer(int(5))),
-        Expr::Primary(Primary::Integer(int(8))),
+    pub static FIVE_EIGHTHS: Lazy<SymExpr> = Lazy::new(|| make_fraction(
+        SymExpr::Primary(Primary::Integer(int(5))),
+        SymExpr::Primary(Primary::Integer(int(8))),
     ));
 
     /// 2/3 = 4pi/3 rad = 240 deg
-    pub static TWO_THIRDS: Lazy<Expr> = Lazy::new(|| make_fraction(
-        Expr::Primary(Primary::Integer(int(2))),
-        Expr::Primary(Primary::Integer(int(3))),
+    pub static TWO_THIRDS: Lazy<SymExpr> = Lazy::new(|| make_fraction(
+        SymExpr::Primary(Primary::Integer(int(2))),
+        SymExpr::Primary(Primary::Integer(int(3))),
     ));
 
     /// 3/4 = 3pi/2 rad = 270 deg
-    pub static THREE_FOURTHS: Lazy<Expr> = Lazy::new(|| make_fraction(
-        Expr::Primary(Primary::Integer(int(3))),
-        Expr::Primary(Primary::Integer(int(4))),
+    pub static THREE_FOURTHS: Lazy<SymExpr> = Lazy::new(|| make_fraction(
+        SymExpr::Primary(Primary::Integer(int(3))),
+        SymExpr::Primary(Primary::Integer(int(4))),
     ));
 
     /// 5/6 = 5pi/3 rad = 300 deg
-    pub static FIVE_SIXTHS: Lazy<Expr> = Lazy::new(|| make_fraction(
-        Expr::Primary(Primary::Integer(int(5))),
-        Expr::Primary(Primary::Integer(int(6))),
+    pub static FIVE_SIXTHS: Lazy<SymExpr> = Lazy::new(|| make_fraction(
+        SymExpr::Primary(Primary::Integer(int(5))),
+        SymExpr::Primary(Primary::Integer(int(6))),
     ));
 
     /// 7/8 = 7pi/4 rad = 315 deg
-    pub static SEVEN_EIGHTHS: Lazy<Expr> = Lazy::new(|| make_fraction(
-        Expr::Primary(Primary::Integer(int(7))),
-        Expr::Primary(Primary::Integer(int(8))),
+    pub static SEVEN_EIGHTHS: Lazy<SymExpr> = Lazy::new(|| make_fraction(
+        SymExpr::Primary(Primary::Integer(int(7))),
+        SymExpr::Primary(Primary::Integer(int(8))),
     ));
 
     /// 11/12 = 11pi/6 rad = 330 deg
-    pub static ELEVEN_TWELFTHS: Lazy<Expr> = Lazy::new(|| make_fraction(
-        Expr::Primary(Primary::Integer(int(11))),
-        Expr::Primary(Primary::Integer(int(12))),
+    pub static ELEVEN_TWELFTHS: Lazy<SymExpr> = Lazy::new(|| make_fraction(
+        SymExpr::Primary(Primary::Integer(int(11))),
+        SymExpr::Primary(Primary::Integer(int(12))),
     ));
 }
 
@@ -130,23 +130,23 @@ pub mod output {
     use super::*;
 
     /// sqrt(2)/2
-    pub static SQRT_TWO_HALF: Lazy<Expr> = Lazy::new(|| make_fraction(
-        Expr::Primary(Primary::Integer(int(2))).sqrt(),
-        Expr::Primary(Primary::Integer(int(2))),
+    pub static SQRT_TWO_HALF: Lazy<SymExpr> = Lazy::new(|| make_fraction(
+        SymExpr::Primary(Primary::Integer(int(2))).sqrt(),
+        SymExpr::Primary(Primary::Integer(int(2))),
     ));
 
     /// sqrt(3)/2
-    pub static SQRT_THREE_HALF: Lazy<Expr> = Lazy::new(|| make_fraction(
-        Expr::Primary(Primary::Integer(int(3))).sqrt(),
-        Expr::Primary(Primary::Integer(int(2))),
+    pub static SQRT_THREE_HALF: Lazy<SymExpr> = Lazy::new(|| make_fraction(
+        SymExpr::Primary(Primary::Integer(int(3))).sqrt(),
+        SymExpr::Primary(Primary::Integer(int(2))),
     ));
 
     /// sqrt(3)/3
-    pub static SQRT_THREE_THIRD: Lazy<Expr> = Lazy::new(|| make_fraction(
-        Expr::Primary(Primary::Integer(int(3))).sqrt(),
-        Expr::Primary(Primary::Integer(int(3))),
+    pub static SQRT_THREE_THIRD: Lazy<SymExpr> = Lazy::new(|| make_fraction(
+        SymExpr::Primary(Primary::Integer(int(3))).sqrt(),
+        SymExpr::Primary(Primary::Integer(int(3))),
     ));
 
     /// sqrt(3)
-    pub static SQRT_THREE: Lazy<Expr> = Lazy::new(|| Expr::Primary(Primary::Integer(int(3))).sqrt());
+    pub static SQRT_THREE: Lazy<SymExpr> = Lazy::new(|| SymExpr::Primary(Primary::Integer(int(3))).sqrt());
 }

--- a/cas-compute/src/symbolic/simplify/rules/trigonometry/table.rs
+++ b/cas-compute/src/symbolic/simplify/rules/trigonometry/table.rs
@@ -1,4 +1,4 @@
-use crate::symbolic::expr::Expr;
+use crate::symbolic::expr::SymExpr;
 use once_cell::sync::Lazy;
 use std::collections::HashMap;
 use super::consts::{input::*, output::*, ONE, ONE_HALF, ZERO};
@@ -7,14 +7,14 @@ use super::consts::{input::*, output::*, ONE, ONE_HALF, ZERO};
 #[derive(PartialEq, Eq, Hash)]
 pub struct TrigOut {
     /// The output of the trigonometric function.
-    pub output: &'static Expr,
+    pub output: &'static SymExpr,
 
     /// Whether to negate the output.
     pub neg: bool,
 }
 
-impl From<&'static Expr> for TrigOut {
-    fn from(output: &'static Expr) -> Self {
+impl From<&'static SymExpr> for TrigOut {
+    fn from(output: &'static SymExpr) -> Self {
         Self {
             output,
             neg: false,
@@ -22,7 +22,7 @@ impl From<&'static Expr> for TrigOut {
     }
 }
 
-pub static SIN_TABLE: Lazy<HashMap<&Expr, TrigOut>> = Lazy::new(|| HashMap::from([
+pub static SIN_TABLE: Lazy<HashMap<&SymExpr, TrigOut>> = Lazy::new(|| HashMap::from([
     // sin(0) = 0
     (&*ZERO, TrigOut::from(&*ZERO)),
 
@@ -75,7 +75,7 @@ pub static SIN_TABLE: Lazy<HashMap<&Expr, TrigOut>> = Lazy::new(|| HashMap::from
     (&*ONE, TrigOut::from(&*ZERO)),
 ]));
 
-pub static COS_TABLE: Lazy<HashMap<&Expr, TrigOut>> = Lazy::new(|| HashMap::from([
+pub static COS_TABLE: Lazy<HashMap<&SymExpr, TrigOut>> = Lazy::new(|| HashMap::from([
     // cos(0) = 1
     (&*ZERO, TrigOut::from(&*ONE)),
 
@@ -128,7 +128,7 @@ pub static COS_TABLE: Lazy<HashMap<&Expr, TrigOut>> = Lazy::new(|| HashMap::from
     (&*ONE, TrigOut::from(&*ONE)),
 ]));
 
-pub static TAN_TABLE: Lazy<HashMap<&Expr, TrigOut>> = Lazy::new(|| HashMap::from([
+pub static TAN_TABLE: Lazy<HashMap<&SymExpr, TrigOut>> = Lazy::new(|| HashMap::from([
     // tan(0) = 0
     (&*ZERO, TrigOut::from(&*ZERO)),
 


### PR DESCRIPTION
Renames `cas_compute::symbolic::Expr` to `SymExpr` to avoid ambiguity with `cas_parser::parser::ast::Expr`.

Closes #7.